### PR TITLE
fix bug with &nbsp;

### DIFF
--- a/twigextensions/HacksawTwigExtension.php
+++ b/twigextensions/HacksawTwigExtension.php
@@ -37,6 +37,9 @@ class HacksawTwigExtension extends \Twig_Extension
 
     public function hacksaw($content, $hack = 'p', $limit = 1, $allow = null, $append = null)
     {
+        // Remove non-breaking spaces to prevent them from turning into black diamonds with question marks
+        $content = preg_replace('~\xc2\xa0~', ' ', $content);
+
         if ($hack == 'c' || $hack == 'chars' || $hack == 'characters')
         {
             $clean_content = $this->cleanHtml($content, $allow);

--- a/twigextensions/HacksawTwigExtension.php
+++ b/twigextensions/HacksawTwigExtension.php
@@ -37,9 +37,6 @@ class HacksawTwigExtension extends \Twig_Extension
 
     public function hacksaw($content, $hack = 'p', $limit = 1, $allow = null, $append = null)
     {
-        // Remove non-breaking spaces to prevent them from turning into black diamonds with question marks
-        $content = preg_replace('~\xc2\xa0~', ' ', $content);
-
         if ($hack == 'c' || $hack == 'chars' || $hack == 'characters')
         {
             $clean_content = $this->cleanHtml($content, $allow);
@@ -70,7 +67,7 @@ class HacksawTwigExtension extends \Twig_Extension
 
                 if ($word_count > $limit)
                 {
-                    $words = preg_split('/\s+/', $clean_content);
+                    $words = preg_split('/\s+/u', $clean_content);
                     $clean_content = implode(' ', array_slice($words, 0, $limit));
                     $return = $clean_content;
 


### PR DESCRIPTION
This fixes the issue described in a comment here: https://craftcms.stackexchange.com/questions/661/best-method-of-text-truncating

> We see an issue with current version of Hacksaw where the content contains non-breaking spaces. They're being converted into little black diamonds with questions marks in them. Redactor loves to add non-breaking spaces, in my experience.